### PR TITLE
SSTPメソッドをNOTIFYに変更。通知情報を追加。

### DIFF
--- a/nokakoi/FormMain.cs
+++ b/nokakoi/FormMain.cs
@@ -59,7 +59,15 @@ namespace nokakoi
         private double _tempOpacity = 1.00;
 
         private readonly DSSTPSender _ds = new("SakuraUnicode");
-        private readonly string _mesHeader = "SEND SSTP/1.0\r\nCharset: UTF-8\r\nSender: nokakoi\r\nOption: nobreak\r\nScript: ";
+        private readonly string _SSTPMethod = "NOTIFY SSTP/1.1";
+        private readonly Dictionary<string, string> _baseSSTPHeader = new(){
+            {"Charset","UTF-8"},
+            {"Sender","nokakoi"},
+            {"Option","nobreak,notranslate"},
+            {"Event","OnNostr"},
+            {"Reference0","Nostr/0.2"}
+        };
+
         private string _ghostName = string.Empty;
         #endregion
 
@@ -257,7 +265,14 @@ namespace nokakoi
                                 if (null != _ds)
                                 {
                                     SearchGhost();
-                                    string sstpmsg = $"{_mesHeader}{speaker}リアクション {userName} {content}\\e\r\n";
+                                    Dictionary<string, string> SSTPHeader = new(_baseSSTPHeader)
+                                    {
+                                        { "Reference1", "reaction" },
+                                        { "Reference2", content },
+                                        { "Reference3", userName },
+                                        { "Script", $"{speaker}リアクション {userName} {content}\\e" }
+                                    };
+                                    string sstpmsg = _SSTPMethod + "\r\n" + String.Join("\r\n", SSTPHeader.Select(kvp => kvp.Key + ": " + kvp.Value)) + "\r\n\r\n";
                                     string r = _ds.GetSSTPResponse(_ghostName, sstpmsg);
                                     Debug.WriteLine(r);
                                 }
@@ -309,7 +324,14 @@ namespace nokakoi
                                 {
                                     msg = $"{msg[.._cutLength]} . . .";//\\u\\p[1]\\s[10]長いよっ！";
                                 }
-                                string sstpmsg = $"{_mesHeader}{speaker}{userName}\\n{msg}\\e\r\n";
+                                Dictionary<string, string> SSTPHeader = new(_baseSSTPHeader)
+                                {
+                                    { "Reference1", "note" },
+                                    { "Reference2", content },
+                                    { "Reference3", userName },
+                                    { "Script", $"{speaker}{userName}\\n{msg}\\e" }
+                                };
+                                string sstpmsg = _SSTPMethod + "\r\n" + String.Join("\r\n", SSTPHeader.Select(kvp => kvp.Key + ": " + kvp.Value)) + "\r\n\r\n";
                                 string res = _ds.GetSSTPResponse(_ghostName, sstpmsg);
                                 //Debug.WriteLine(res);
                             }


### PR DESCRIPTION
## 要旨

現在、SSTPのSENDメソッドによりゴーストにSakuraScriptを再生させるのみですが、
これをNOTIFYメソッドに変えることでゴーストに情報を通知するようにします。

```
NOTIFY SSTP/1.1
Charset: UTF-8
Sender: nokakoi
Option: nobreak,notranslate
Event: OnNostr
Reference0: Nostr/0.2
Reference1: note
Reference2: てすと
Reference3: 投稿者名
Script: \u\p[1]\s[10]投稿者名\nてすと\e
```

これまでと動作は変わらないはずです(ただしOptionにnotranslateがあったほうがいいかなと思って追加しました)。
https://ssp.shillest.net/ukadoc/manual/spec_sstp.html#req_res

## SSTPの歴史と経緯について

SSTP送信者は、SENDではなくNOTIFYメソッドを使用するほうが行儀が良いとされています。

ゴースト作者の中には自作のキャラクターに合わない台詞を喋らせられることを快く思わない方もいます。
ゴーストが通知された情報を受けて自身の言葉で喋らせることができるよう改良された仕様がNOTIFYです。
http://usada.sakura.vg/contents/sstp.html

## 通知の仕様について

[angolmoisの通知の仕様](https://github.com/nikolat/angolmois?tab=readme-ov-file#%E3%82%B4%E3%83%BC%E3%82%B9%E3%83%88%E5%81%B4%E3%81%AE%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%9E%E3%82%A4%E3%82%BA%E4%BC%BA%E3%81%8B%E7%B5%8C%E9%A8%93%E8%80%85%E5%90%91%E3%81%91)を真似ています(互換ではないのでReference0をNostr/0.2としています)

Reference2に未加工のcontentを入れることでゴースト側で学習に使用するなどの応用が考えられます。
